### PR TITLE
fix: Looking at office causes a lagspike

### DIFF
--- a/src/constructs/MainLibraryRoom.ts
+++ b/src/constructs/MainLibraryRoom.ts
@@ -63,7 +63,7 @@ export class MainLibraryConstruct extends Construct {
         this.addConstruct(this.music);
 
         this.office = new OfficeConstruct(this.graphics, this.physics, this.interactions, this.userInterface);
-        // this.addConstruct(this.office);
+        this.addConstruct(this.office);
     }
 
     /*      const tempBookShelf = this.bookshelf.clone();
@@ -327,7 +327,8 @@ export class MainLibraryConstruct extends Construct {
 
         this.graphics.add(this.lightHemisphere);
         this.graphics.add(this.lightDirectional);
-        
+
+
     }
 
     // Box collider dimensions are half the dimensions of the actual object

--- a/src/lib/w3ads/Project.ts
+++ b/src/lib/w3ads/Project.ts
@@ -118,6 +118,13 @@ export class Project {
             this.currentScene._create();
             await this.currentScene._load();
             this.currentScene._build();
+
+            // First time render to force the full scene to load into the GPU - helps avoid lagspikes midgame by forcing
+            // that lagspike into the load time of a scene
+            this.currentScene.graphics.root.traverse(obj => obj.frustumCulled = false);
+            this.renderer.render(this.currentScene.graphics.root, this.currentScene.graphics.mainCamera);
+            this.currentScene.graphics.root.traverse(obj => obj.frustumCulled = true);
+
             this.play();
         }
     }


### PR DESCRIPTION
This was fixed by rendering at least one frame of the whole scene with no frustum culling. So every object is loaded into the gpu right at the start of the scene

Frustum culling is immediately turned back on

fixes #46 